### PR TITLE
Bump to v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 - PATCH version when backwards compatible bug **fixes** are implemented.
 
 ## [Unreleased]
+
+## [0.1.1] - 2025-05-26
 ### Removed
 - bigint-buffer dependency
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starksign",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SDK to facilitate Node integrations with Stark Sign",
   "main": "starksign/index.js",
   "directories": {


### PR DESCRIPTION
### Removed
- bigint-buffer dependency
### Fixed
- parseAndVerify function parameters